### PR TITLE
Fix Node 20 deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ jobs:
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: 1.21
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get dependencies
         run: |
@@ -23,7 +23,7 @@ jobs:
         run: go build .
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
 
       - name: Test
         run: ./bin/test


### PR DESCRIPTION
# Fix Node 20 deprecation in vat workflow

## Summary

GitHub is retiring the **Node 20 action runtime**; actions bundling a Node 20 entrypoint emit deprecation warnings today and will eventually stop running. This PR bumps every JavaScript action to the version that ships a **Node 24** runtime.

## Changes

| Action | Before (node20) | After (node24) |
|---|---|---|
| `actions/checkout` | `@v4` | `@v5` |
| `actions/setup-go` | `@v4` | `@v6` |
| `golangci/golangci-lint-action` | `@v7` | `@v9` |

File touched: `.github/workflows/` (single workflow).

- **`golangci-lint-action@v7` → `@v9`** (node20 → node24). The repo's `.golangci.yml` is already **v2-format** (`version: "2"`) and the step passes no args, so the bump is clean.

## Verification

Confirmed via each pinned `action.yml` (`runs.using:`):

- `checkout@v4` → node20; `@v5` → node24
- `setup-go@v4` → node20; `@v6` → node24
- `golangci-lint-action@v7` → node20; `@v9` → node24

Diff is version strings only, no other edits.

## Runner requirement

The job runs on **`ubuntu-latest`** (GitHub-hosted), which already supports the Node 24 runtime — no runner action needed.

## Testing

- [ ] Run the workflow and confirm checkout / setup-go / golangci-lint run without Node deprecation warnings.
